### PR TITLE
Initial OpenRPC docs - with state subscription

### DIFF
--- a/Documentation/API Backend/openrpc/README.md
+++ b/Documentation/API Backend/openrpc/README.md
@@ -1,0 +1,16 @@
+# OpenRPC Document
+
+The API is documented here using the OpenRPC 1.2.4 standard. Note that there are later published versions of the standard, but the available tooling is implemented for the v1.2.4 spec.
+
+The full api is defined in openrpc.json, however, this means reading and updating a single file would become unwieldy and merge conflicts would arise. To mitigate this, [open-rpc-compiler](https://www.npmjs.com/package/open-rpc-compiler?activeTab=readme) is used to break each method and schema into its own file organized in this directory's subdirectories, named for the elements they comprise in the openrpc.json doc.
+
+
+## Install
+```
+npm install open-rpc-compiler --no-save
+```
+
+To compile the elements into the openrpc.json file run the following command from this directory.
+```
+open-rpc-compile > openrpc.json
+```

--- a/Documentation/API Backend/openrpc/components/schemas/jointPosition.json
+++ b/Documentation/API Backend/openrpc/components/schemas/jointPosition.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "properties": {
+        "jointIndex": {
+            "type": "integer"
+        },
+        "position": {
+            "type": "integer"
+        }
+    }
+}

--- a/Documentation/API Backend/openrpc/components/schemas/jointPositions.json
+++ b/Documentation/API Backend/openrpc/components/schemas/jointPositions.json
@@ -1,0 +1,6 @@
+{
+    "type": "array",
+    "items": {
+        "$ref": "#components/schemas/jointPosition"
+    }
+}

--- a/Documentation/API Backend/openrpc/components/schemas/jointPositions.json
+++ b/Documentation/API Backend/openrpc/components/schemas/jointPositions.json
@@ -1,6 +1,6 @@
 {
     "type": "array",
     "items": {
-        "$ref": "#components/schemas/jointPosition"
+        "$ref": "#/components/schemas/jointPosition"
     }
 }

--- a/Documentation/API Backend/openrpc/components/schemas/state.json
+++ b/Documentation/API Backend/openrpc/components/schemas/state.json
@@ -5,7 +5,7 @@
             "type": "boolean"
         },
         "jointPositions": {
-            "$ref": "#components/schemas/jointPositions"
+            "$ref": "#/components/schemas/jointPositions"
         }
     }
 }

--- a/Documentation/API Backend/openrpc/components/schemas/state.json
+++ b/Documentation/API Backend/openrpc/components/schemas/state.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "properties": {
+        "robotOnline": {
+            "type": "boolean"
+        },
+        "jointPositions": {
+            "$ref": "#components/schemas/jointPositions"
+        }
+    }
+}

--- a/Documentation/API Backend/openrpc/info.json
+++ b/Documentation/API Backend/openrpc/info.json
@@ -1,0 +1,4 @@
+{
+    "version": "0.1.0",
+    "title": "Motion Controller API"
+}

--- a/Documentation/API Backend/openrpc/methods/getActiveSubscriptions.json
+++ b/Documentation/API Backend/openrpc/methods/getActiveSubscriptions.json
@@ -1,6 +1,6 @@
 {
     "name": "getActiveSubscriptions",
-    "description": "Get a list of state keys that the client is currently subscribed to",
+    "description": "Get a list of state keys for which the client is currently subscribed to value changes",
     "params": [],
     "result": {
         "name": "activeStateKeySubscriptions",

--- a/Documentation/API Backend/openrpc/methods/getActiveSubscriptions.json
+++ b/Documentation/API Backend/openrpc/methods/getActiveSubscriptions.json
@@ -1,0 +1,15 @@
+{
+    "name": "getActiveSubscriptions",
+    "description": "Get a list of state keys that the client is currently subscribed to",
+    "params": [],
+    "result": {
+        "name": "activeStateKeySubscriptions",
+        "description": "the state keys to which the client is currently subsribed",
+        "schema": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/Documentation/API Backend/openrpc/methods/getState.json
+++ b/Documentation/API Backend/openrpc/methods/getState.json
@@ -25,7 +25,7 @@
             }
         },
         {
-            "name": "subscribe",
+            "name": "subscribeToChanges",
             "required": false,
             "description": "Subscribe to changes in the keys included in the request",
             "schema": {

--- a/Documentation/API Backend/openrpc/methods/getState.json
+++ b/Documentation/API Backend/openrpc/methods/getState.json
@@ -1,0 +1,43 @@
+{
+    "name": "getState",
+    "description": "Get the current state",
+    "params": [
+        {
+            "name": "include",
+            "description": "state keys that should be included in the response. If undefined, all keys except any specifially excluded are included.",
+            "required": false,
+            "schema": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        {
+            "name": "exclude",
+            "description": "state keys that should not be included in the response.",
+            "required": false,
+            "schema": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        {
+            "name": "subscribe",
+            "required": false,
+            "description": "Subscribe to the state keys included by the request",
+            "schema": {
+                "type": "boolean"
+            }
+        }
+    ],
+    "result": {
+        "name": "state",
+        "description": "the current state. For subscription updates, only changed keys for changed values will be included.",
+        "schema": {
+            "$ref": "#components/schemas/state"
+        }
+    }
+}

--- a/Documentation/API Backend/openrpc/methods/getState.json
+++ b/Documentation/API Backend/openrpc/methods/getState.json
@@ -1,6 +1,6 @@
 {
     "name": "getState",
-    "description": "Get the current state",
+    "description": "Get the current state and optionally subscribe to changes",
     "params": [
         {
             "name": "include",
@@ -27,7 +27,7 @@
         {
             "name": "subscribe",
             "required": false,
-            "description": "Subscribe to the state keys included by the request",
+            "description": "Subscribe to changes in the keys included in the request",
             "schema": {
                 "type": "boolean"
             }
@@ -35,7 +35,7 @@
     ],
     "result": {
         "name": "state",
-        "description": "the current state. For subscription updates, only changed keys for changed values will be included.",
+        "description": "the current state. For subscription updates, only keys for changed values will be included.",
         "schema": {
             "$ref": "#components/schemas/state"
         }

--- a/Documentation/API Backend/openrpc/methods/getState.json
+++ b/Documentation/API Backend/openrpc/methods/getState.json
@@ -37,7 +37,7 @@
         "name": "state",
         "description": "the current state. For subscription updates, only keys for changed values will be included.",
         "schema": {
-            "$ref": "#components/schemas/state"
+            "$ref": "#/components/schemas/state"
         }
     }
 }

--- a/Documentation/API Backend/openrpc/methods/tags/motion/getPosition.json
+++ b/Documentation/API Backend/openrpc/methods/tags/motion/getPosition.json
@@ -8,7 +8,7 @@
         "schema": {
             "type": "array",
             "items": {
-                "$ref": "#components/schemas/jointPosition"
+                "$ref": "#/components/schemas/jointPosition"
             }
         }
     },

--- a/Documentation/API Backend/openrpc/methods/tags/motion/getPosition.json
+++ b/Documentation/API Backend/openrpc/methods/tags/motion/getPosition.json
@@ -1,0 +1,34 @@
+{
+    "name": "getPosition",
+    "description": "Get current joint positions",
+    "params": [],
+    "result": {
+        "name": "jointPositions",
+        "description": "updated joint positions",
+        "schema": {
+            "type": "array",
+            "items": {
+                "$ref": "#components/schemas/jointPosition"
+            }
+        }
+    },
+    "examples": [
+        {
+            "name": "getPosition",
+            "params": [],
+            "result": {
+                "name": "jointPositions",
+                "value": [
+                    {
+                        "jointIndex": 1,
+                        "position": 393
+                    },
+                    {
+                        "jointIndex": 5,
+                        "position": 1829
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Documentation/API Backend/openrpc/methods/tags/motion/jogJoint.json
+++ b/Documentation/API Backend/openrpc/methods/tags/motion/jogJoint.json
@@ -1,0 +1,46 @@
+{
+    "name": "jogJoint",
+    "description": "Jog an joint with a specified velocity",
+    "params": [
+        {
+            "name": "jointIndex",
+            "description": "The index of the joint to jog",
+            "schema": {
+                "type": "integer"
+            }
+        },
+        {
+            "name": "direction",
+            "description": "Direction to jog the joint.",
+            "schema": {
+                "type": "integer"
+            }
+        },
+        {
+            "name": "speed",
+            "description": "The speed at which to jog.",
+            "schema": {
+                "type": "integer"
+            }
+        }
+    ],
+    "examples": [
+        {
+            "name": "jogJoint",
+            "params": [
+                {
+                    "name": "jointIndex",
+                    "value": 3
+                },
+                {
+                    "name": "direction",
+                    "value": 1
+                },
+                {
+                    "name": "speed",
+                    "value": 88
+                }
+            ]
+        }
+    ]
+}

--- a/Documentation/API Backend/openrpc/methods/tags/motion/jogJoint.json
+++ b/Documentation/API Backend/openrpc/methods/tags/motion/jogJoint.json
@@ -24,6 +24,12 @@
             }
         }
     ],
+    "result": {
+        "name": "noResult",
+        "schema": {
+            "type": "null"
+        }
+    },
     "examples": [
         {
             "name": "jogJoint",
@@ -40,7 +46,11 @@
                     "name": "speed",
                     "value": 88
                 }
-            ]
+            ],
+            "result": {
+                "name": "noResult",
+                "value": null
+            }
         }
     ]
 }

--- a/Documentation/API Backend/openrpc/methods/unsubscribeState.json
+++ b/Documentation/API Backend/openrpc/methods/unsubscribeState.json
@@ -24,5 +24,11 @@
                 }
             }
         }
-    ]
+    ],
+    "result": {
+        "name": "noResult",
+        "schema": {
+            "type": "null"
+        }
+    }
 }

--- a/Documentation/API Backend/openrpc/methods/unsubscribeState.json
+++ b/Documentation/API Backend/openrpc/methods/unsubscribeState.json
@@ -1,0 +1,28 @@
+{
+    "name": "unsubscribeState",
+    "description": "Get the current state",
+    "params": [
+        {
+            "name": "include",
+            "description": "state keys that should be unsubscribed from. If undefined, all keys except any specifially excluded are included.",
+            "required": false,
+            "schema": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        },
+        {
+            "name": "exclude",
+            "description": "state keys that should not be unsubscribed from",
+            "required": false,
+            "schema": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            }
+        }
+    ]
+}

--- a/Documentation/API Backend/openrpc/methods/unsubscribeState.json
+++ b/Documentation/API Backend/openrpc/methods/unsubscribeState.json
@@ -1,6 +1,6 @@
 {
     "name": "unsubscribeState",
-    "description": "Get the current state",
+    "description": "Unsubscribe from changes to state",
     "params": [
         {
             "name": "include",

--- a/Documentation/API Backend/openrpc/openrpc.json
+++ b/Documentation/API Backend/openrpc/openrpc.json
@@ -7,7 +7,7 @@
   "methods": [
     {
       "name": "getActiveSubscriptions",
-      "description": "Get a list of state keys that the client is currently subscribed to",
+      "description": "Get a list of state keys for which the client is currently subscribed to value changes",
       "params": [],
       "result": {
         "name": "activeStateKeySubscriptions",
@@ -47,7 +47,7 @@
           }
         },
         {
-          "name": "subscribe",
+          "name": "subscribeToChanges",
           "required": false,
           "description": "Subscribe to changes in the keys included in the request",
           "schema": {

--- a/Documentation/API Backend/openrpc/openrpc.json
+++ b/Documentation/API Backend/openrpc/openrpc.json
@@ -59,7 +59,7 @@
         "name": "state",
         "description": "the current state. For subscription updates, only keys for changed values will be included.",
         "schema": {
-          "$ref": "#components/schemas/state"
+          "$ref": "#/components/schemas/state"
         }
       }
     },
@@ -73,7 +73,7 @@
         "schema": {
           "type": "array",
           "items": {
-            "$ref": "#components/schemas/jointPosition"
+            "$ref": "#/components/schemas/jointPosition"
           }
         }
       },
@@ -128,6 +128,12 @@
           }
         }
       ],
+      "result": {
+        "name": "noResult",
+        "schema": {
+          "type": "null"
+        }
+      },
       "examples": [
         {
           "name": "jogJoint",
@@ -144,7 +150,11 @@
               "name": "speed",
               "value": 88
             }
-          ]
+          ],
+          "result": {
+            "name": "noResult",
+            "value": null
+          }
         }
       ],
       "tags": [
@@ -179,7 +189,13 @@
             }
           }
         }
-      ]
+      ],
+      "result": {
+        "name": "noResult",
+        "schema": {
+          "type": "null"
+        }
+      }
     }
   ],
   "components": {
@@ -198,7 +214,7 @@
       "jointPositions": {
         "type": "array",
         "items": {
-          "$ref": "#components/schemas/jointPosition"
+          "$ref": "#/components/schemas/jointPosition"
         }
       },
       "state": {
@@ -208,7 +224,7 @@
             "type": "boolean"
           },
           "jointPositions": {
-            "$ref": "#components/schemas/jointPositions"
+            "$ref": "#/components/schemas/jointPositions"
           }
         }
       }

--- a/Documentation/API Backend/openrpc/openrpc.json
+++ b/Documentation/API Backend/openrpc/openrpc.json
@@ -1,0 +1,114 @@
+{
+  "openrpc": "1.2.4",
+  "info": {
+    "version": "0.1.0",
+    "title": "Motion Controller API"
+  },
+  "methods": [
+    {
+      "name": "getPosition",
+      "description": "Get current joint positions",
+      "params": [],
+      "result": {
+        "name": "jointPositions",
+        "description": "updated joint positions",
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#components/schemas/jointPosition"
+          }
+        }
+      },
+      "examples": [
+        {
+          "name": "getPosition",
+          "params": [],
+          "result": {
+            "name": "jointPositions",
+            "value": [
+              {
+                "jointIndex": 1,
+                "position": 393
+              },
+              {
+                "jointIndex": 5,
+                "position": 1829
+              }
+            ]
+          }
+        }
+      ],
+      "tags": [
+        {
+          "name": "motion"
+        }
+      ]
+    },
+    {
+      "name": "jogJoint",
+      "description": "Jog an joint with a specified velocity",
+      "params": [
+        {
+          "name": "jointIndex",
+          "description": "The index of the joint to jog",
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "direction",
+          "description": "Direction to jog the joint.",
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "speed",
+          "description": "The speed at which to jog.",
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ],
+      "examples": [
+        {
+          "name": "jogJoint",
+          "params": [
+            {
+              "name": "jointIndex",
+              "value": 3
+            },
+            {
+              "name": "direction",
+              "value": 1
+            },
+            {
+              "name": "speed",
+              "value": 88
+            }
+          ]
+        }
+      ],
+      "tags": [
+        {
+          "name": "motion"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "schemas": {
+      "jointPosition": {
+        "type": "object",
+        "properties": {
+          "jointIndex": {
+            "type": "integer"
+          },
+          "position": {
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/Documentation/API Backend/openrpc/openrpc.json
+++ b/Documentation/API Backend/openrpc/openrpc.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "getState",
-      "description": "Get the current state",
+      "description": "Get the current state and optionally subscribe to changes",
       "params": [
         {
           "name": "include",
@@ -49,7 +49,7 @@
         {
           "name": "subscribe",
           "required": false,
-          "description": "Subscribe to the state keys included by the request",
+          "description": "Subscribe to changes in the keys included in the request",
           "schema": {
             "type": "boolean"
           }
@@ -57,7 +57,7 @@
       ],
       "result": {
         "name": "state",
-        "description": "the current state. For subscription updates, only changed keys for changed values will be included.",
+        "description": "the current state. For subscription updates, only keys for changed values will be included.",
         "schema": {
           "$ref": "#components/schemas/state"
         }
@@ -155,7 +155,7 @@
     },
     {
       "name": "unsubscribeState",
-      "description": "Get the current state",
+      "description": "Unsubscribe from changes to state",
       "params": [
         {
           "name": "include",

--- a/Documentation/API Backend/openrpc/openrpc.json
+++ b/Documentation/API Backend/openrpc/openrpc.json
@@ -6,6 +6,64 @@
   },
   "methods": [
     {
+      "name": "getActiveSubscriptions",
+      "description": "Get a list of state keys that the client is currently subscribed to",
+      "params": [],
+      "result": {
+        "name": "activeStateKeySubscriptions",
+        "description": "the state keys to which the client is currently subsribed",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    {
+      "name": "getState",
+      "description": "Get the current state",
+      "params": [
+        {
+          "name": "include",
+          "description": "state keys that should be included in the response. If undefined, all keys except any specifially excluded are included.",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "name": "exclude",
+          "description": "state keys that should not be included in the response.",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "name": "subscribe",
+          "required": false,
+          "description": "Subscribe to the state keys included by the request",
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "result": {
+        "name": "state",
+        "description": "the current state. For subscription updates, only changed keys for changed values will be included.",
+        "schema": {
+          "$ref": "#components/schemas/state"
+        }
+      }
+    },
+    {
       "name": "getPosition",
       "description": "Get current joint positions",
       "params": [],
@@ -94,6 +152,34 @@
           "name": "motion"
         }
       ]
+    },
+    {
+      "name": "unsubscribeState",
+      "description": "Get the current state",
+      "params": [
+        {
+          "name": "include",
+          "description": "state keys that should be unsubscribed from. If undefined, all keys except any specifially excluded are included.",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "name": "exclude",
+          "description": "state keys that should not be unsubscribed from",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      ]
     }
   ],
   "components": {
@@ -106,6 +192,23 @@
           },
           "position": {
             "type": "integer"
+          }
+        }
+      },
+      "jointPositions": {
+        "type": "array",
+        "items": {
+          "$ref": "#components/schemas/jointPosition"
+        }
+      },
+      "state": {
+        "type": "object",
+        "properties": {
+          "robotOnline": {
+            "type": "boolean"
+          },
+          "jointPositions": {
+            "$ref": "#components/schemas/jointPositions"
           }
         }
       }


### PR DESCRIPTION
Each method and schema is organized in its own file and compiled with the tool I created open-rpc-compiler into a single openrpc.json representing the complete API

A state schema is defined that is the basis of subsriptions.